### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run all quality checks (includes pre-commit hooks)
         run: |
-          make check-all
+          make check
 
   test-lessons:
     name: Test All Lessons


### PR DESCRIPTION
CI check is failing 

```
make check-all
make: *** No rule to make target `check-all'.  Stop.
```