### PR TITLE
fix: drop assistant prefill from structured output tutorial

### DIFF
--- a/01-foundations/02-prompt-engineering/05_structured_output_anthropic.py
+++ b/01-foundations/02-prompt-engineering/05_structured_output_anthropic.py
@@ -4,8 +4,13 @@ Structured Output & Prompt Scaffolding (Anthropic)
 Demonstrates three approaches for getting structured JSON from Claude, progressing from
 least to most reliable:
 1. Prompt-based JSON — asking for JSON in the system prompt (can fail)
-2. XML scaffolding + prefill — Anthropic-specific prompting techniques (more reliable)
+2. XML scaffolding — Anthropic-specific prompting technique (more reliable)
 3. Native JSON schema — API-level schema enforcement via output_config (guaranteed)
+
+Note: earlier versions of this tutorial also demonstrated assistant-message *prefill*
+(seeding the assistant turn with `{` to force JSON). Claude 4.6 removed support for
+assistant prefill — the conversation must end with a user message — so that step has
+been dropped. See https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-6
 
 All three methods extract the same product information from one description,
 making it easy to compare reliability across techniques.
@@ -91,26 +96,24 @@ class StructuredOutputClient:
         messages = [{"role": "user", "content": description}]
         return self._call(system, messages)
 
-    def extract_with_prefill(self, description: str) -> str:
-        """Use XML scaffolding + assistant prefill — Anthropic-specific technique."""
+    def extract_with_xml_scaffolding(self, description: str) -> str:
+        """Use XML scaffolding — Anthropic-specific prompting technique."""
         schema_str = json.dumps(PRODUCT_SCHEMA_DESCRIPTION, indent=2)
         system = (
             "You are a product data extraction assistant. Extract structured information "
-            "from product descriptions as JSON matching the provided schema."
+            "from product descriptions as JSON matching the provided schema.\n\n"
+            "Respond with ONLY the JSON object — no markdown fences, no commentary."
         )
         # XML tags help Claude parse the input structure
         user_content = (
             f"<schema>\n{schema_str}\n</schema>\n\n"
             f"<product_description>\n{description}\n</product_description>"
         )
-        # Prefill: start the assistant's response with '{' to force JSON output
-        messages = [
-            {"role": "user", "content": user_content},
-            {"role": "assistant", "content": "{"},
-        ]
-        raw = self._call(system, messages)
-        # Reconstruct the full JSON since we prefilled the opening brace
-        return "{" + raw
+        # Note: Claude 4.6 removed assistant-message prefill, so the previous
+        # {"role": "assistant", "content": "{"} trick no longer works. XML tags
+        # alone still significantly improve structural adherence.
+        messages = [{"role": "user", "content": user_content}]
+        return self._call(system, messages)
 
     def extract_with_native_schema(self, description: str) -> str:
         """Use native JSON schema enforcement via output_config — guaranteed valid JSON."""
@@ -165,7 +168,7 @@ def _display_result(console: Console, method_name: str, raw: str) -> None:
 
 METHOD_LABELS = [
     "A: Prompt-Based JSON",
-    "B: XML Scaffolding + Prefill",
+    "B: XML Scaffolding",
     "C: Native JSON Schema",
 ]
 
@@ -193,26 +196,30 @@ def _run_method_a(console: Console, client: StructuredOutputClient) -> None:
 
 
 def _run_method_b(console: Console, client: StructuredOutputClient) -> None:
-    """Run the XML scaffolding + prefill extraction method."""
+    """Run the XML scaffolding extraction method."""
     schema_str = json.dumps(PRODUCT_SCHEMA_DESCRIPTION, indent=2)
-    console.print("[dim]Wrap input in XML tags, prefill assistant response with '{'.[/dim]\n")
+    console.print(
+        "[dim]Wrap input in XML tags so Claude clearly separates schema from data.[/dim]\n"
+        "[dim]Assistant prefill used to pair with this technique, but Claude 4.6 "
+        "removed support.[/dim]\n"
+    )
     prompt_b = (
         "**System prompt:**\n"
         "```\n"
         "You are a product data extraction assistant...\n"
+        "Respond with ONLY the JSON object.\n"
         "```\n\n"
         "**User message (XML-structured):**\n"
         "```xml\n"
         f"<schema>\n{schema_str}\n</schema>\n\n"
         "<product_description>\n(product description here)\n</product_description>\n"
-        "```\n\n"
-        "**Assistant prefill:** `{` _(forces the model to start with JSON)_\n"
+        "```\n"
     )
     console.print(Markdown(prompt_b))
 
     try:
-        raw = client.extract_with_prefill(PRODUCT_DESCRIPTION)
-        _display_result(console, "B: XML + Prefill", raw)
+        raw = client.extract_with_xml_scaffolding(PRODUCT_DESCRIPTION)
+        _display_result(console, "B: XML Scaffolding", raw)
     except Exception as e:
         logger.error("Error in method B: %s", e)
 
@@ -256,7 +263,7 @@ def main() -> None:
         "[bold cyan]Structured Output & Prompt Scaffolding[/bold cyan]\n\n"
         "Comparing 3 techniques for extracting structured JSON from free-form text:\n"
         "  A. Prompt-based JSON — ask for JSON in the system prompt\n"
-        "  B. XML scaffolding + prefill — Anthropic-specific prompting technique\n"
+        "  B. XML scaffolding — Anthropic-specific prompting technique\n"
         "  C. Native JSON schema — API-level enforcement via output_config (recommended)\n\n"
         f"[bold]Product Description:[/bold]\n{PRODUCT_DESCRIPTION}",
         title="Prompt Engineering — Anthropic",

--- a/01-foundations/02-prompt-engineering/README.md
+++ b/01-foundations/02-prompt-engineering/README.md
@@ -14,7 +14,7 @@ Learn how to shape LLM behavior through prompting techniques. Every AI agent's c
 - Apply few-shot prompting for in-context learning
 - Guide reasoning with chain-of-thought (CoT) prompting
 - Extract structured JSON output via prompt instructions
-- Use provider-specific techniques: Anthropic XML scaffolding + prefill, OpenAI JSON schema enforcement
+- Use provider-specific techniques: Anthropic XML scaffolding, OpenAI JSON schema enforcement
 - Compare prompting strategies side-by-side to understand their trade-offs
 
 ## 📦 Available Examples
@@ -25,7 +25,7 @@ Learn how to shape LLM behavior through prompting techniques. Every AI agent's c
 | ![OpenAI](../../common/badges/openai.svg)       | [02_system_prompts_openai.py](02_system_prompts_openai.py)             | System prompts & role engineering                             |
 | ![Anthropic](../../common/badges/anthropic.svg) | [03_few_shot_cot_anthropic.py](03_few_shot_cot_anthropic.py)           | Zero-shot, few-shot & chain-of-thought demos                  |
 | ![OpenAI](../../common/badges/openai.svg)       | [04_few_shot_cot_openai.py](04_few_shot_cot_openai.py)                 | Zero-shot, few-shot & chain-of-thought demos                  |
-| ![Anthropic](../../common/badges/anthropic.svg) | [05_structured_output_anthropic.py](05_structured_output_anthropic.py) | Product extraction — prompt, XML prefill & native schema      |
+| ![Anthropic](../../common/badges/anthropic.svg) | [05_structured_output_anthropic.py](05_structured_output_anthropic.py) | Product extraction — prompt, XML scaffolding & native schema  |
 | ![OpenAI](../../common/badges/openai.svg)       | [06_structured_output_openai.py](06_structured_output_openai.py)       | Product extraction — prompt, scaffolding & schema enforcement |
 
 ## 🚀 Quick Start
@@ -158,14 +158,15 @@ response = client.messages.parse(
 product = response.parsed_output  # Validated Pydantic model instance
 ```
 
-**Anthropic — XML scaffolding + assistant prefill (prompting technique):**
+**Anthropic — XML scaffolding (prompting technique):**
 ```python
-# XML tags structure the input, prefill forces JSON start
+# XML tags structure the input — clearly separate schema from data
 messages = [
     {"role": "user", "content": "<schema>...</schema>\n<product_description>...</product_description>"},
-    {"role": "assistant", "content": "{"},  # Prefill technique
 ]
 ```
+
+> **Note:** Earlier Claude models supported *assistant-message prefill* — seeding the assistant turn with `{` to force JSON output. Claude 4.6 [removed support](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-6#breaking-changes) for this: the conversation must end with a user message. If you need prefill-style guarantees today, prefer native schema enforcement (below).
 
 **OpenAI — native JSON schema enforcement:**
 ```python
@@ -182,7 +183,7 @@ response = client.responses.create(
 )
 ```
 
-> **Both providers now offer schema enforcement.** Anthropic's `output_config` and OpenAI's `text.format` both guarantee valid JSON via constrained decoding. Prompt-based techniques (prefill, XML scaffolding) remain useful for older models or when you need more control over the prompting strategy.
+> **Both providers now offer schema enforcement.** Anthropic's `output_config` and OpenAI's `text.format` both guarantee valid JSON via constrained decoding. Prompt-based techniques (XML scaffolding) remain useful when you need more control over the prompting strategy.
 
 ### 5. Output Validation
 


### PR DESCRIPTION
## Summary
- Claude 4.6 [removed support](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-6#breaking-changes) for assistant-message prefill, breaking method B of `05_structured_output_anthropic.py` with a 400 error.
- Method B now demonstrates XML scaffolding alone (still a valid Anthropic-specific prompting technique); the `{"role": "assistant", "content": "{"}` seed and the `"{" + raw` reconstruction are gone.
- README, menu labels, and docstrings updated; added a short note explaining why prefill was dropped and linking to the breaking-changes doc.

Closes #43

## Test plan
- [x] \`uv run ruff check\` + \`uv run ruff format --check\` pass on the edited file
- [x] \`ast.parse\` succeeds
- [ ] Run \`uv run --directory 01-foundations/02-prompt-engineering python 05_structured_output_anthropic.py\` and exercise method B end-to-end against Claude 4.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)