### PR TITLE
docs: embed animated architecture GIFs across all tutorials

### DIFF
--- a/01-foundations/01-simple-llm-call/README.md
+++ b/01-foundations/01-simple-llm-call/README.md
@@ -40,16 +40,11 @@ Or use the [Code Runner](https://marketplace.visualstudio.com/items?itemName=for
 
 ### 1. Simple LLM Call Flow
 
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart LR
-    A(["⚡ Input Prompt"]) -->|request| B["🧠 LLM Call   "]
-    B -->|response| C(["📄 Response Text"])
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/simple-llm-call.gif" alt="A simple LLM call: you send a prompt to the model, and tokens stream back as the response" width="640">
+</p>
+
+A prompt goes in, the model generates, and tokens stream back — that round trip is one LLM call.
 
 ### 2. LLM Client Initialization
 

--- a/01-foundations/01-simple-llm-call/README.md
+++ b/01-foundations/01-simple-llm-call/README.md
@@ -41,7 +41,7 @@ Or use the [Code Runner](https://marketplace.visualstudio.com/items?itemName=for
 ### 1. Simple LLM Call Flow
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/simple-llm-call.gif" alt="A simple LLM call: you send a prompt to the model, and tokens stream back as the response" width="640">
+  <img src="https://graphics.agenticloops.ai/animations/foundations/simple-llm-call.gif" alt="A simple LLM call: you send a prompt to the model, and tokens stream back as the response" width="640">
 </p>
 
 A prompt goes in, the model generates, and tokens stream back — that round trip is one LLM call.

--- a/01-foundations/02-prompt-engineering/README.md
+++ b/01-foundations/02-prompt-engineering/README.md
@@ -45,18 +45,9 @@ Or use the [Code Runner](https://marketplace.visualstudio.com/items?itemName=for
 
 ### 1. Prompt Engineering Layers
 
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart LR
-    A(["🗣️ System Prompt "]) -->|shape behavior| D["🧠 LLM Call   "]
-    B(["📝 Few-Shot Examples"]) -->|teach patterns| D
-    C(["📋 Output Schema "]) -->|constrain format| D
-    D -->|response| E(["📄 Structured Output"])
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/prompt-engineering.gif" alt="Prompt engineering: a system prompt, few-shot examples, and an output schema all feed into the LLM to produce a structured response" width="640">
+</p>
 
 Each layer adds more control over the LLM's response. Used together, they let you build agents that produce reliable, parseable output.
 

--- a/01-foundations/02-prompt-engineering/README.md
+++ b/01-foundations/02-prompt-engineering/README.md
@@ -46,7 +46,7 @@ Or use the [Code Runner](https://marketplace.visualstudio.com/items?itemName=for
 ### 1. Prompt Engineering Layers
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/prompt-engineering.gif" alt="Prompt engineering: a system prompt, few-shot examples, and an output schema all feed into the LLM to produce a structured response" width="640">
+  <img src="https://graphics.agenticloops.ai/animations/foundations/prompt-engineering.gif" alt="Prompt engineering: a system prompt, few-shot examples, and an output schema all feed into the LLM to produce a structured response" width="640">
 </p>
 
 Each layer adds more control over the LLM's response. Used together, they let you build agents that produce reliable, parseable output.

--- a/01-foundations/03-chat/README.md
+++ b/01-foundations/03-chat/README.md
@@ -40,19 +40,9 @@ Or use the [Code Runner](https://marketplace.visualstudio.com/items?itemName=for
 
 ### 1. Chat Loop Pattern
 
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart TD
-    A(["🗣️ User Input      "]) -->|append| B["📝 Store in History "]
-    B -->|send| C["🧠 LLM Call       "]
-    C -->|append| D["📝 Store Response   "]
-    D -->|render| E(["💬 Display Output   "])
-    E -->|loop| A
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/chat.gif" alt="Interactive chat loop: each message is appended to the conversation history, the full history is sent to the LLM every turn, and the reply loops back as history keeps growing" width="520">
+</p>
 
 ### 2. Message History Management
 

--- a/01-foundations/03-chat/README.md
+++ b/01-foundations/03-chat/README.md
@@ -41,7 +41,7 @@ Or use the [Code Runner](https://marketplace.visualstudio.com/items?itemName=for
 ### 1. Chat Loop Pattern
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/chat.gif" alt="Interactive chat loop: each message is appended to the conversation history, the full history is sent to the LLM every turn, and the reply loops back as history keeps growing" width="520">
+  <img src="https://graphics.agenticloops.ai/animations/foundations/chat.gif" alt="Interactive chat loop: each message is appended to the conversation history, the full history is sent to the LLM every turn, and the reply loops back as history keeps growing" width="520">
 </p>
 
 ### 2. Message History Management

--- a/01-foundations/04-tool-use/README.md
+++ b/01-foundations/04-tool-use/README.md
@@ -88,6 +88,10 @@ TOOLS = [
 
 ### 2. The Tool Call Loop
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/tool-use.gif" alt="Tool use: the model receives a task, calls a tool with arguments, reads the result returned by the tool, and answers grounded in real data" width="680">
+</p>
+
 The LLM doesn't execute tools directly - it requests tool calls that you execute:
 
 ```

--- a/01-foundations/04-tool-use/README.md
+++ b/01-foundations/04-tool-use/README.md
@@ -89,7 +89,7 @@ TOOLS = [
 ### 2. The Tool Call Loop
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/tool-use.gif" alt="Tool use: the model receives a task, calls a tool with arguments, reads the result returned by the tool, and answers grounded in real data" width="680">
+  <img src="https://graphics.agenticloops.ai/animations/foundations/tool-use.gif" alt="Tool use: the model receives a task, calls a tool with arguments, reads the result returned by the tool, and answers grounded in real data" width="680">
 </p>
 
 The LLM doesn't execute tools directly - it requests tool calls that you execute:

--- a/01-foundations/05-agent-loop/README.md
+++ b/01-foundations/05-agent-loop/README.md
@@ -43,7 +43,7 @@ Or use the [Code Runner](https://marketplace.visualstudio.com/items?itemName=for
 The core pattern is simple: call the LLM, execute any requested tools, feed results back, repeat until done.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/agent-loop.gif" alt="The agent loop: the agent evaluates whether a tool is needed, runs tools and feeds results back in a loop, and exits when no tool is required" width="720">
+  <img src="https://graphics.agenticloops.ai/animations/foundations/agent-loop.gif" alt="The agent loop: the agent evaluates whether a tool is needed, runs tools and feeds results back in a loop, and exits when no tool is required" width="720">
 </p>
 
 ```python

--- a/01-foundations/05-agent-loop/README.md
+++ b/01-foundations/05-agent-loop/README.md
@@ -42,20 +42,9 @@ Or use the [Code Runner](https://marketplace.visualstudio.com/items?itemName=for
 
 The core pattern is simple: call the LLM, execute any requested tools, feed results back, repeat until done.
 
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart TD
-    A(["🗣️ User Task        "]) -->|init| B["🧠 LLM Call      "]
-    B -->|evaluate| C{"⚙️ Tool Calls?     "}
-    C -->|"no tools"| D(["📄 Return Response  "])
-    C -->|"has tools"| E["🔧 Execute Tools    "]
-    E -->|collect| F["📝 Append Results   "]
-    F -->|iterate| B
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/agent-loop.gif" alt="The agent loop: the agent evaluates whether a tool is needed, runs tools and feeds results back in a loop, and exits when no tool is required" width="720">
+</p>
 
 ```python
 while iteration < max_iterations:

--- a/01-foundations/06-codebase-navigator/README.md
+++ b/01-foundations/06-codebase-navigator/README.md
@@ -67,25 +67,9 @@ The loop continues until the LLM responds with just text (no tool calls), indica
 
 ### RAG Pipeline
 
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart TB
-  subgraph Indexing["📥 Indexing"]
-    direction LR
-    A["📁 Repository"] -->|chunk| B["📄 Chunks"]
-    B -->|embed| C["🔢 Vectors"]
-
-  end
-  C -->|store| D["🗄️ ChromaDB"]  
-
-  E["🗣️ User Query"] -->|embed| F["🔢 Query Vector"]
-  F -->|similarity search| D
-  D -->|relevant chunks| G["🧠 LLM"]
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/codebase-navigator.gif" alt="RAG pipeline: the repository is indexed into a vector store, a question searches the vectors by similarity, and the most relevant code is retrieved so the model can answer grounded in real code" width="720">
+</p>
 
 **Chunking strategy**: Python files split on top-level `class`/`def` definitions. Other files split every 50 lines with 10-line overlap. Simple heuristics that work well for educational purposes.
 

--- a/01-foundations/06-codebase-navigator/README.md
+++ b/01-foundations/06-codebase-navigator/README.md
@@ -68,7 +68,7 @@ The loop continues until the LLM responds with just text (no tool calls), indica
 ### RAG Pipeline
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/codebase-navigator.gif" alt="RAG pipeline: the repository is indexed into a vector store, a question searches the vectors by similarity, and the most relevant code is retrieved so the model can answer grounded in real code" width="720">
+  <img src="https://graphics.agenticloops.ai/animations/foundations/codebase-navigator.gif" alt="RAG pipeline: the repository is indexed into a vector store, a question searches the vectors by similarity, and the most relevant code is retrieved so the model can answer grounded in real code" width="720">
 </p>
 
 **Chunking strategy**: Python files split on top-level `class`/`def` definitions. Other files split every 50 lines with 10-line overlap. Simple heuristics that work well for educational purposes.

--- a/01-foundations/README.md
+++ b/01-foundations/README.md
@@ -8,7 +8,7 @@ description: "Master the core building blocks of AI agents through progressive, 
 Master the core building blocks of AI agents through progressive, hands-on tutorials.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/foundations-overview.gif" alt="Foundations progression: a simple LLM call grows into prompt engineering, then chat with history, tool use, the autonomous agent loop, and finally retrieval-augmented generation (RAG)." width="820">
+  <img src="https://graphics.agenticloops.ai/animations/foundations/foundations-overview.gif" alt="Foundations progression: a simple LLM call grows into prompt engineering, then chat with history, tool use, the autonomous agent loop, and finally retrieval-augmented generation (RAG)." width="820">
 </p>
 
 <!-- TODO: Add reference to blog post "How Agents Work: The Patterns Behind the Magic" on Substack -->

--- a/01-foundations/README.md
+++ b/01-foundations/README.md
@@ -7,6 +7,10 @@ description: "Master the core building blocks of AI agents through progressive, 
 
 Master the core building blocks of AI agents through progressive, hands-on tutorials.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/foundations-overview.gif" alt="Foundations progression: a simple LLM call grows into prompt engineering, then chat with history, tool use, the autonomous agent loop, and finally retrieval-augmented generation (RAG)." width="820">
+</p>
+
 <!-- TODO: Add reference to blog post "How Agents Work: The Patterns Behind the Magic" on Substack -->
 
 ## 🗺️ Progression Path

--- a/02-effective-agents/01-prompt-chaining/README.md
+++ b/02-effective-agents/01-prompt-chaining/README.md
@@ -39,7 +39,7 @@ Or use the [Code Runner](https://marketplace.visualstudio.com/items?itemName=for
 ### Sequential Pipeline
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/prompt-chaining.gif" alt="A topic flows through a sequential pipeline of focused LLM steps — Outliner, Writer with web search, then Editor — each output feeding the next to produce a final blog post." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/effective-agents/prompt-chaining.gif" alt="A topic flows through a sequential pipeline of focused LLM steps — Outliner, Writer with web search, then Editor — each output feeding the next to produce a final blog post." width="720">
 </p>
 
 Each step has a focused system prompt and a single responsibility. The output of one step becomes the input of the next.

--- a/02-effective-agents/01-prompt-chaining/README.md
+++ b/02-effective-agents/01-prompt-chaining/README.md
@@ -38,18 +38,9 @@ Or use the [Code Runner](https://marketplace.visualstudio.com/items?itemName=for
 
 ### Sequential Pipeline
 
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart LR
-    A["🗣️ Topic     "] -->|request| B["🧠 Outliner / Sonnet     "]
-    B -->|outline| C["🧠 Writer / Haiku + 🔍     "]
-    C -->|draft| D["🧠 Editor / Sonnet     "]
-    D -->|polished| E["📄 Final Post     "]
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/prompt-chaining.gif" alt="A topic flows through a sequential pipeline of focused LLM steps — Outliner, Writer with web search, then Editor — each output feeding the next to produce a final blog post." width="720">
+</p>
 
 Each step has a focused system prompt and a single responsibility. The output of one step becomes the input of the next.
 

--- a/02-effective-agents/02-routing/README.md
+++ b/02-effective-agents/02-routing/README.md
@@ -61,7 +61,7 @@ The key insight: a tutorial needs prerequisites before steps, a news article nee
 Routing builds on prompt chaining (each route *is* a chain) but adds a classification step that determines which chain to execute:
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/routing.gif" alt="A classifier inspects an incoming topic and dispatches it to one of several specialized chains — tutorial, news, or concept — which each produce structurally distinct output." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/effective-agents/routing.gif" alt="A classifier inspects an incoming topic and dispatches it to one of several specialized chains — tutorial, news, or concept — which each produce structurally distinct output." width="720">
 </p>
 
 Use routing when inputs require **structurally different** processing, not just different tones or styles.

--- a/02-effective-agents/02-routing/README.md
+++ b/02-effective-agents/02-routing/README.md
@@ -60,21 +60,9 @@ The key insight: a tutorial needs prerequisites before steps, a news article nee
 
 Routing builds on prompt chaining (each route *is* a chain) but adds a classification step that determines which chain to execute:
 
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart LR
-    A["🗣️ Topic     "] -->|request| B["⚙️ Classify     "]
-    B -->|tutorial| C["🔧 Tutorial Chain     "]
-    B -->|news| D["🔧 News Chain     "]
-    B -->|concept| E["🔧 Concept Chain     "]
-    C --> F["📄 Output     "]
-    D --> F
-    E --> F
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/routing.gif" alt="A classifier inspects an incoming topic and dispatches it to one of several specialized chains — tutorial, news, or concept — which each produce structurally distinct output." width="720">
+</p>
 
 Use routing when inputs require **structurally different** processing, not just different tones or styles.
 

--- a/02-effective-agents/03-parallelization/README.md
+++ b/02-effective-agents/03-parallelization/README.md
@@ -42,7 +42,7 @@ Or use the [Code Runner](https://marketplace.visualstudio.com/items?itemName=for
 A blog post (selected from `input/` or pasted custom) is sent to 3 independent writers simultaneously:
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/parallelization.gif" alt="A single blog post fans out concurrently to LinkedIn, Twitter, and Newsletter writers, whose results fan back in to an aggregator that combines them into one promo pack." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/effective-agents/parallelization.gif" alt="A single blog post fans out concurrently to LinkedIn, Twitter, and Newsletter writers, whose results fan back in to an aggregator that combines them into one promo pack." width="720">
 </p>
 
 Each writer has a focused system prompt and runs as a separate thread. Results are collected as they complete and aggregated into a "Promo Pack" saved to `output/`.

--- a/02-effective-agents/03-parallelization/README.md
+++ b/02-effective-agents/03-parallelization/README.md
@@ -41,21 +41,9 @@ Or use the [Code Runner](https://marketplace.visualstudio.com/items?itemName=for
 
 A blog post (selected from `input/` or pasted custom) is sent to 3 independent writers simultaneously:
 
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart TD
-    A["📄 Blog Post     "] -->|fan-out| B["🧠 LinkedIn Writer     "]
-    A -->|fan-out| C["🧠 Twitter Writer     "]
-    A -->|fan-out| D["🧠 Newsletter Writer     "]
-    B -->|result| E["⚙️ Aggregator     "]
-    C -->|result| E
-    D -->|result| E
-    E -->|combine| F["📄 Promo Pack     "]
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/parallelization.gif" alt="A single blog post fans out concurrently to LinkedIn, Twitter, and Newsletter writers, whose results fan back in to an aggregator that combines them into one promo pack." width="720">
+</p>
 
 Each writer has a focused system prompt and runs as a separate thread. Results are collected as they complete and aggregated into a "Promo Pack" saved to `output/`.
 

--- a/02-effective-agents/04-orchestrator-workers/README.md
+++ b/02-effective-agents/04-orchestrator-workers/README.md
@@ -37,7 +37,7 @@ Or use the [Code Runner](https://marketplace.visualstudio.com/items?itemName=for
 ## 🔑 Key Concepts
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/orchestrator-workers.gif" alt="An orchestrator LLM dynamically plans subtopics for a topic, delegates them to parallel worker LLMs, then a synthesizer combines their research into a final article." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/effective-agents/orchestrator-workers.gif" alt="An orchestrator LLM dynamically plans subtopics for a topic, delegates them to parallel worker LLMs, then a synthesizer combines their research into a final article." width="720">
 </p>
 
 ### Dynamic Decomposition

--- a/02-effective-agents/04-orchestrator-workers/README.md
+++ b/02-effective-agents/04-orchestrator-workers/README.md
@@ -36,22 +36,9 @@ Or use the [Code Runner](https://marketplace.visualstudio.com/items?itemName=for
 
 ## 🔑 Key Concepts
 
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart TD
-    A["🗣️ Topic     "] -->|request| B["🧠 Orchestrator     "]
-    B -->|"plan (dynamic)"| C["🔧 Worker 1     "]
-    B -->|"plan (dynamic)"| D["🔧 Worker 2     "]
-    B -->|"plan (dynamic)"| E["🔧 Worker N     "]
-    C -->|research| F["🧠 Synthesizer     "]
-    D -->|research| F
-    E -->|research| F
-    F -->|combine| G["📄 Final Article     "]
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/orchestrator-workers.gif" alt="An orchestrator LLM dynamically plans subtopics for a topic, delegates them to parallel worker LLMs, then a synthesizer combines their research into a final article." width="720">
+</p>
 
 ### Dynamic Decomposition
 

--- a/02-effective-agents/05-evaluator-optimizer/README.md
+++ b/02-effective-agents/05-evaluator-optimizer/README.md
@@ -37,7 +37,7 @@ Or use the [Code Runner](https://marketplace.visualstudio.com/items?itemName=for
 ## 🔑 Key Concepts
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/evaluator-optimizer.gif" alt="A draft flows through research, writing, and evaluation, looping back to a refiner while the average score stays below threshold and exiting to a final post once it passes." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/effective-agents/evaluator-optimizer.gif" alt="A draft flows through research, writing, and evaluation, looping back to a refiner while the average score stays below threshold and exiting to a final post once it passes." width="720">
 </p>
 
 ### Pipeline: Research → Write → Evaluate → Refine

--- a/02-effective-agents/05-evaluator-optimizer/README.md
+++ b/02-effective-agents/05-evaluator-optimizer/README.md
@@ -36,20 +36,9 @@ Or use the [Code Runner](https://marketplace.visualstudio.com/items?itemName=for
 
 ## 🔑 Key Concepts
 
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart TD
-    A["🗣️ Topic     "] -->|request| B["🔧 Research / Haiku + 🔍     "]
-    B -->|data| C["🧠 Write / Haiku     "]
-    C -->|draft| D["⚙️ Evaluate / Haiku     "]
-    D -->|"avg < 7.0"| E["🧠 Refine / Sonnet     "]
-    E -->|revised| D
-    D -->|"avg >= 7.0"| F["📄 Final Post     "]
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/evaluator-optimizer.gif" alt="A draft flows through research, writing, and evaluation, looping back to a refiner while the average score stays below threshold and exiting to a final post once it passes." width="720">
+</p>
 
 ### Pipeline: Research → Write → Evaluate → Refine
 

--- a/02-effective-agents/06-human-in-the-loop/README.md
+++ b/02-effective-agents/06-human-in-the-loop/README.md
@@ -37,7 +37,7 @@ Or use the [Code Runner](https://marketplace.visualstudio.com/items?itemName=for
 ## 🔑 Key Concepts
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/human-in-the-loop.gif" alt="An LLM drafts an email that pauses at human checkpoints where a person can approve, edit, or reject with feedback, looping back through revision until the email is approved." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/effective-agents/human-in-the-loop.gif" alt="An LLM drafts an email that pauses at human checkpoints where a person can approve, edit, or reject with feedback, looping back through revision until the email is approved." width="720">
 </p>
 
 ### Checkpoint Placement

--- a/02-effective-agents/06-human-in-the-loop/README.md
+++ b/02-effective-agents/06-human-in-the-loop/README.md
@@ -36,23 +36,9 @@ Or use the [Code Runner](https://marketplace.visualstudio.com/items?itemName=for
 
 ## 🔑 Key Concepts
 
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart TD
-    A["🗣️ Request     "] -->|request| B["🧠 Draft     "]
-    B -->|draft| C["👤 Checkpoint 1     "]
-    C -->|approve| D["📄 Final Email     "]
-    C -->|"reject + feedback"| E["🧠 Revise     "]
-    C -->|edit| D
-    E -->|revised| F["👤 Checkpoint 2     "]
-    F -->|approve| D
-    F -->|"reject + feedback"| E
-    F -->|edit| D
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/human-in-the-loop.gif" alt="An LLM drafts an email that pauses at human checkpoints where a person can approve, edit, or reject with feedback, looping back through revision until the email is approved." width="720">
+</p>
 
 ### Checkpoint Placement
 

--- a/02-effective-agents/07-content-writer/README.md
+++ b/02-effective-agents/07-content-writer/README.md
@@ -48,30 +48,9 @@ uv run --directory 02-effective-agents/07-content-writer python 01_content_write
     └── tools.py                     # Tool schemas (classify, plan, evaluate, SEO) + web search
 ```
 
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart TD
-    A["🗣️ User Input     "] -->|topic| B["⚙️ Classify (Routing)     "]
-    B -->|content_type| HC1["👤 Human Checkpoint 1     "]
-    HC1 --> C["⚙️ Plan (Orchestrator)     "]
-    C -->|subtopics| HC2["👤 Human Checkpoint 2     "]
-    HC2 --> D["🔧 Research (Workers)     "]
-    D -->|"parallel web search"| D
-    D -->|sections| E["📝 Write (Chaining)     "]
-    E -->|draft| F["⚙️ Evaluate     "]
-    F -->|"avg < 7.0"| G["📝 Refine     "]
-    G -->|revised| F
-    F -->|"avg >= 7.0"| HC3["👤 Human Checkpoint 3     "]
-    HC3 -->|approved| H["📣 Social Media (Fan-out)     "]
-    H -->|"parallel: LinkedIn + Twitter + Newsletter"| H
-    H --> I["🏷️ SEO Title (Voting)     "]
-    I -->|"3 candidates → evaluator"| I
-    I --> J["📄 Complete Package     "]
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/content-writer.gif" alt="A full content pipeline composes every pattern — classify, plan, parallel research, write, evaluate-refine loop, three human checkpoints, social media fan-out, and SEO title voting — into one end-to-end agent producing a complete package." width="720">
+</p>
 
 ## 🔑 Key Concepts
 

--- a/02-effective-agents/07-content-writer/README.md
+++ b/02-effective-agents/07-content-writer/README.md
@@ -49,7 +49,7 @@ uv run --directory 02-effective-agents/07-content-writer python 01_content_write
 ```
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/content-writer.gif" alt="A full content pipeline composes every pattern — classify, plan, parallel research, write, evaluate-refine loop, three human checkpoints, social media fan-out, and SEO title voting — into one end-to-end agent producing a complete package." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/effective-agents/content-writer.gif" alt="A full content pipeline composes every pattern — classify, plan, parallel research, write, evaluate-refine loop, three human checkpoints, social media fan-out, and SEO title voting — into one end-to-end agent producing a complete package." width="720">
 </p>
 
 ## 🔑 Key Concepts

--- a/02-effective-agents/README.md
+++ b/02-effective-agents/README.md
@@ -10,7 +10,7 @@ Architectural patterns that separate toy demos from real agents. Based on Anthro
 ## 🗺️ Progression Path
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/effective-agents-overview.gif" alt="A progression path showing each effective-agent pattern building on the last — prompt chaining, routing, parallelization, orchestrator-workers, evaluator-optimizer, and human-in-the-loop — combining into the final content writer agent." width="820">
+  <img src="https://graphics.agenticloops.ai/animations/effective-agents/effective-agents-overview.gif" alt="A progression path showing each effective-agent pattern building on the last — prompt chaining, routing, parallelization, orchestrator-workers, evaluator-optimizer, and human-in-the-loop — combining into the final content writer agent." width="820">
 </p>
 
 | Step | Tutorial | What It Adds |

--- a/02-effective-agents/README.md
+++ b/02-effective-agents/README.md
@@ -9,20 +9,9 @@ Architectural patterns that separate toy demos from real agents. Based on Anthro
 
 ## 🗺️ Progression Path
 
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart TD
-    A["1 · ⛓️ Prompt Chaining     "] -->|"+ classification"| B["2 · 🔀 Routing     "]
-    B -->|"+ concurrency"| C["3 · ⚡ Parallelization     "]
-    C -->|"+ dynamic planning"| D["4 · 🎯 Orchestrator-Workers     "]
-    D -->|"+ self-critique"| E["5 · 🔄 Evaluator-Optimizer     "]
-    E -->|"+ human oversight"| F["6 · 👤 Human-in-the-Loop     "]
-    F -->|"combine all"| G["🏆 Content Writer     "]
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/effective-agents-overview.gif" alt="A progression path showing each effective-agent pattern building on the last — prompt chaining, routing, parallelization, orchestrator-workers, evaluator-optimizer, and human-in-the-loop — combining into the final content writer agent." width="820">
+</p>
 
 | Step | Tutorial | What It Adds |
 |:----:|----------|-------------|

--- a/03-advanced-techniques/01-structured-output/README.md
+++ b/03-advanced-techniques/01-structured-output/README.md
@@ -117,7 +117,7 @@ class TicketAnalysis(BaseModel):
 The retry loop: extract → validate → on error, send validation message back → retry.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/structured-output.gif" alt="Self-healing extraction loop where input text is parsed by the LLM, validated by Pydantic, and on error the validation feedback is sent back to retry until a valid result is produced." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/advanced-techniques/structured-output.gif" alt="Self-healing extraction loop where input text is parsed by the LLM, validated by Pydantic, and on error the validation feedback is sent back to retry until a valid result is produced." width="720">
 </p>
 
 ### Technique 4: Batch Extraction

--- a/03-advanced-techniques/01-structured-output/README.md
+++ b/03-advanced-techniques/01-structured-output/README.md
@@ -116,19 +116,9 @@ class TicketAnalysis(BaseModel):
 
 The retry loop: extract → validate → on error, send validation message back → retry.
 
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart LR
-    A["🗣️ Input Text"] --> B["🧠 LLM Extract"]
-    B --> C["⚙️ Pydantic\nValidate"]
-    C -->|"✅ valid"| D["📄 Result"]
-    C -->|"❌ error"| E["📝 Error\nFeedback"]
-    E -->|"retry"| B
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/structured-output.gif" alt="Self-healing extraction loop where input text is parsed by the LLM, validated by Pydantic, and on error the validation feedback is sent back to retry until a valid result is produced." width="720">
+</p>
 
 ### Technique 4: Batch Extraction
 

--- a/03-advanced-techniques/02-streaming/README.md
+++ b/03-advanced-techniques/02-streaming/README.md
@@ -11,7 +11,7 @@ Make agents feel alive with real-time, token-by-token responses. Every tutorial 
 The real challenge isn't basic streaming — it's streaming with tool calls. When Claude decides to call a tool mid-response, you need to detect it, execute the tool, feed the result back, and resume streaming. This tutorial makes that approachable.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/streaming.gif" alt="Token-by-token streaming where text deltas render live in the terminal, a tool_use block is detected mid-stream and executed, and the stream resumes with the tool result fed back into the response." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/advanced-techniques/streaming.gif" alt="Token-by-token streaming where text deltas render live in the terminal, a tool_use block is detected mid-stream and executed, and the stream resumes with the tool result fed back into the response." width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/03-advanced-techniques/02-streaming/README.md
+++ b/03-advanced-techniques/02-streaming/README.md
@@ -10,6 +10,10 @@ Make agents feel alive with real-time, token-by-token responses. Every tutorial 
 
 The real challenge isn't basic streaming — it's streaming with tool calls. When Claude decides to call a tool mid-response, you need to detect it, execute the tool, feed the result back, and resume streaming. This tutorial makes that approachable.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/streaming.gif" alt="Token-by-token streaming where text deltas render live in the terminal, a tool_use block is detected mid-stream and executed, and the stream resumes with the tool result fed back into the response." width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Stream Claude responses token-by-token using `client.messages.stream()`

--- a/03-advanced-techniques/03-context-engineering/README.md
+++ b/03-advanced-techniques/03-context-engineering/README.md
@@ -118,7 +118,7 @@ The summary preserves key facts and decisions. Recent messages stay verbatim so 
 
 <!-- prettier-ignore -->
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/context-engineering.gif" alt="Compression flow where each user message is appended to history, and if history exceeds the budget the older messages are split off and summarized before sending to the LLM and showing the updated budget." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/advanced-techniques/context-engineering.gif" alt="Compression flow where each user message is appended to history, and if history exceeds the budget the older messages are split off and summarized before sending to the LLM and showing the updated budget." width="720">
 </p>
 
 ### 5. Why Summarize Instead of Drop?

--- a/03-advanced-techniques/03-context-engineering/README.md
+++ b/03-advanced-techniques/03-context-engineering/README.md
@@ -117,23 +117,9 @@ The summary preserves key facts and decisions. Recent messages stay verbatim so 
 ### 4. Compression Flow
 
 <!-- prettier-ignore -->
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart TD
-    A["🗣️ User Message     "] --> B["📝 Append to History "]
-    B --> C{"⚙️ History > Budget? "}
-    C -- No --> D["🧠 Send to LLM      "]
-    C -- Yes --> E["✂️ Split Messages    "]
-    E --> F["🧠 Summarize Old     "]
-    F --> G["📝 Replace with Summary"]
-    G --> D
-    D --> H["💬 Display Response  "]
-    H --> I["📊 Show Budget       "]
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/context-engineering.gif" alt="Compression flow where each user message is appended to history, and if history exceeds the budget the older messages are split off and summarized before sending to the LLM and showing the updated budget." width="720">
+</p>
 
 ### 5. Why Summarize Instead of Drop?
 

--- a/03-advanced-techniques/04-cost-optimization/README.md
+++ b/03-advanced-techniques/04-cost-optimization/README.md
@@ -113,20 +113,9 @@ On the first call, `cache_creation_input_tokens > 0`. On subsequent calls with t
 Not every task needs your most capable (and expensive) model. A routing layer classifies each task and sends it to the right model:
 
 <!-- prettier-ignore -->
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart TD
-    A["🗣️ User Task         "] --> B["🧠 Classifier (Haiku) "]
-    B -- "easy" --> C["🧠 Haiku              "]
-    B -- "hard" --> D["🧠 Sonnet             "]
-    C --> E["📄 Response           "]
-    D --> E
-    E --> F["💰 Cost Tracking      "]
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/cost-optimization.gif" alt="Model routing flow where a cheap Haiku classifier labels each task as easy or hard and routes it to Haiku or Sonnet accordingly, then tracks the resulting cost." width="720">
+</p>
 
 The classifier itself runs on Haiku (cheap), adding minimal overhead. Even with the classification cost, routing simple tasks to Haiku saves significantly vs sending everything to Sonnet.
 

--- a/03-advanced-techniques/04-cost-optimization/README.md
+++ b/03-advanced-techniques/04-cost-optimization/README.md
@@ -114,7 +114,7 @@ Not every task needs your most capable (and expensive) model. A routing layer cl
 
 <!-- prettier-ignore -->
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/cost-optimization.gif" alt="Model routing flow where a cheap Haiku classifier labels each task as easy or hard and routes it to Haiku or Sonnet accordingly, then tracks the resulting cost." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/advanced-techniques/cost-optimization.gif" alt="Model routing flow where a cheap Haiku classifier labels each task as easy or hard and routes it to Haiku or Sonnet accordingly, then tracks the resulting cost." width="720">
 </p>
 
 The classifier itself runs on Haiku (cheap), adding minimal overhead. Even with the classification cost, routing simple tasks to Haiku saves significantly vs sending everything to Sonnet.

--- a/03-advanced-techniques/05-memory/README.md
+++ b/03-advanced-techniques/05-memory/README.md
@@ -47,23 +47,9 @@ Or use the [Code Runner](https://marketplace.visualstudio.com/items?itemName=for
 
 Agents need different kinds of memory for different purposes — just like humans distinguish between what they're currently thinking about, what happened recently, and what they know as facts.
 
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart TD
-    A["🗣️ User Input     "] -->|"chat"| B["🧠 Agent Loop     "]
-    B -->|"store"| C["💭 Working Memory  "]
-    B -->|"store"| D["📝 Episodic Memory "]
-    B -->|"store"| E["🔍 Semantic Memory "]
-    C -.->|"session only"| B
-    D -->|"keyword search"| B
-    E -->|"vector search"| B
-    D -->|"JSON file"| F["💾 data/episodic.json"]
-    E -->|"ChromaDB"| G["💾 data/chroma/    "]
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/memory.gif" alt="Three-tier memory architecture where the agent loop stores and retrieves across working memory, episodic memory backed by a JSON file with keyword search, and semantic memory backed by ChromaDB with vector search." width="720">
+</p>
 
 | Tier | Purpose | Storage | Lifespan | Search |
 |------|---------|---------|----------|--------|

--- a/03-advanced-techniques/05-memory/README.md
+++ b/03-advanced-techniques/05-memory/README.md
@@ -48,7 +48,7 @@ Or use the [Code Runner](https://marketplace.visualstudio.com/items?itemName=for
 Agents need different kinds of memory for different purposes — just like humans distinguish between what they're currently thinking about, what happened recently, and what they know as facts.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/memory.gif" alt="Three-tier memory architecture where the agent loop stores and retrieves across working memory, episodic memory backed by a JSON file with keyword search, and semantic memory backed by ChromaDB with vector search." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/advanced-techniques/memory.gif" alt="Three-tier memory architecture where the agent loop stores and retrieves across working memory, episodic memory backed by a JSON file with keyword search, and semantic memory backed by ChromaDB with vector search." width="720">
 </p>
 
 | Tier | Purpose | Storage | Lifespan | Search |

--- a/03-advanced-techniques/06-rag-techniques/README.md
+++ b/03-advanced-techniques/06-rag-techniques/README.md
@@ -65,7 +65,7 @@ Not every application needs RAG. The decision depends on your knowledge base siz
 
 <!-- prettier-ignore -->
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/rag-techniques.gif" alt="RAG pipeline where documents are chunked, embedded, and indexed once into Chroma and BM25, then each query is searched via vector and keyword paths, fused with RRF, reranked, and passed to Claude to generate an answer with citations." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/advanced-techniques/rag-techniques.gif" alt="RAG pipeline where documents are chunked, embedded, and indexed once into Chroma and BM25, then each query is searched via vector and keyword paths, fused with RRF, reranked, and passed to Claude to generate an answer with citations." width="720">
 </p>
 
 ### 3. Chunking

--- a/03-advanced-techniques/06-rag-techniques/README.md
+++ b/03-advanced-techniques/06-rag-techniques/README.md
@@ -64,32 +64,9 @@ Not every application needs RAG. The decision depends on your knowledge base siz
 ### 2. The RAG Pipeline
 
 <!-- prettier-ignore -->
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart LR
-    subgraph Indexing ["📥 Indexing (once)"]
-        A["📄 Documents    "] --> B["✂️ Chunk         "]
-        B --> C["🔢 Embed (local) "]
-        C --> D["💾 Index (Chroma)"]
-        B --> E["💾 BM25 Index   "]
-    end
-
-    subgraph Retrieval ["🔍 Retrieval (per query)"]
-        F["🗣️ Query         "] --> G["🔢 Embed Query   "]
-        G --> H["🔍 Vector Search "]
-        F --> I["🔍 BM25 Search   "]
-        H --> J["🔀 RRF Fusion    "]
-        I --> J
-        J --> K["📊 Rerank        "]
-    end
-
-    K --> L["🧠 Generate (Claude)"]
-    L --> M["📄 Answer + Citations"]
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/rag-techniques.gif" alt="RAG pipeline where documents are chunked, embedded, and indexed once into Chroma and BM25, then each query is searched via vector and keyword paths, fused with RRF, reranked, and passed to Claude to generate an answer with citations." width="720">
+</p>
 
 ### 3. Chunking
 

--- a/03-advanced-techniques/07-multimodal/README.md
+++ b/03-advanced-techniques/07-multimodal/README.md
@@ -114,17 +114,9 @@ for part in response.candidates[0].content.parts:
 
 ### 4. Audio Pipeline
 
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart LR
-    A["📝 Text Input   "] -->|"TTS"| B["🔊 Audio File   "]
-    B -->|"STT"| C["📝 Transcription "]
-    C -->|"compare"| D["✅ Verification  "]
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/multimodal.gif" alt="Audio round-trip pipeline where text input is converted to an audio file via text-to-speech, transcribed back to text via speech-to-text, then compared against the original for verification." width="720">
+</p>
 
 OpenAI provides separate endpoints for each direction:
 

--- a/03-advanced-techniques/07-multimodal/README.md
+++ b/03-advanced-techniques/07-multimodal/README.md
@@ -115,7 +115,7 @@ for part in response.candidates[0].content.parts:
 ### 4. Audio Pipeline
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/multimodal.gif" alt="Audio round-trip pipeline where text input is converted to an audio file via text-to-speech, transcribed back to text via speech-to-text, then compared against the original for verification." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/advanced-techniques/multimodal.gif" alt="Audio round-trip pipeline where text input is converted to an audio file via text-to-speech, transcribed back to text via speech-to-text, then compared against the original for verification." width="720">
 </p>
 
 OpenAI provides separate endpoints for each direction:

--- a/03-advanced-techniques/08-guardrails/README.md
+++ b/03-advanced-techniques/08-guardrails/README.md
@@ -38,20 +38,9 @@ Or use the [Code Runner](https://marketplace.visualstudio.com/items?itemName=for
 Every message passes through guards before and after the agent processes it:
 
 <!-- prettier-ignore -->
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart LR
-    A["User Input     "] --> B["Input Guard    "]
-    B -- "blocked" --> C["Rejection      "]
-    B -- "passed" --> D["Agent          "]
-    D --> E["Output Guard   "]
-    E -- "issues" --> F["Warning/Retry  "]
-    E -- "clean" --> G["Response       "]
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/guardrails.gif" alt="Guardrail pipeline where user input passes through an input guard that blocks or forwards to the agent, whose output then passes through an output guard that flags issues for retry or releases a clean response." width="720">
+</p>
 
 The input guard catches attacks *before* they reach the agent. The output guard verifies the response *before* the user sees it. This dual layer means a single bypass isn't enough to exploit the system.
 

--- a/03-advanced-techniques/08-guardrails/README.md
+++ b/03-advanced-techniques/08-guardrails/README.md
@@ -39,7 +39,7 @@ Every message passes through guards before and after the agent processes it:
 
 <!-- prettier-ignore -->
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/guardrails.gif" alt="Guardrail pipeline where user input passes through an input guard that blocks or forwards to the agent, whose output then passes through an output guard that flags issues for retry or releases a clean response." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/advanced-techniques/guardrails.gif" alt="Guardrail pipeline where user input passes through an input guard that blocks or forwards to the agent, whose output then passes through an output guard that flags issues for retry or releases a clean response." width="720">
 </p>
 
 The input guard catches attacks *before* they reach the agent. The output guard verifies the response *before* the user sees it. This dual layer means a single bypass isn't enough to exploit the system.

--- a/03-advanced-techniques/README.md
+++ b/03-advanced-techniques/README.md
@@ -12,7 +12,7 @@ Practical engineering problems you'll hit the moment agents leave the prototype 
 ## 🗺️ Progression Path
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/advanced-techniques-overview.gif" alt="Progression path through the advanced techniques module, building from structured output to streaming, context engineering, cost optimization, memory, RAG, multimodal, and guardrails." width="820">
+  <img src="https://graphics.agenticloops.ai/animations/advanced-techniques/advanced-techniques-overview.gif" alt="Progression path through the advanced techniques module, building from structured output to streaming, context engineering, cost optimization, memory, RAG, multimodal, and guardrails." width="820">
 </p>
 
 | Step | Tutorial | What It Adds |

--- a/03-advanced-techniques/README.md
+++ b/03-advanced-techniques/README.md
@@ -11,21 +11,9 @@ Practical engineering problems you'll hit the moment agents leave the prototype 
 
 ## 🗺️ Progression Path
 
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart TD
-    A["1 · 📋 Structured Output     "] -->|"+ real-time output"| B["2 · 🌊 Streaming     "]
-    B -->|"+ window strategies"| C["3 · 🧠 Context Engineering     "]
-    C -->|"+ cost reduction"| D["4 · 💰 Cost Optimization     "]
-    D -->|"+ persistence"| E["5 · 📝 Memory Systems     "]
-    E -->|"+ retrieval"| F["6 · 🔍 RAG Techniques     "]
-    F -->|"+ non-text input"| G["7 · 🖼️ Multimodal     "]
-    G -->|"+ safety & quality"| H["8 · 🛡️ Guardrails     "]
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/advanced-techniques-overview.gif" alt="Progression path through the advanced techniques module, building from structured output to streaming, context engineering, cost optimization, memory, RAG, multimodal, and guardrails." width="820">
+</p>
 
 | Step | Tutorial | What It Adds |
 |:----:|----------|-------------|

--- a/04-testing-evaluation/01-unit-testing-agents/README.md
+++ b/04-testing-evaluation/01-unit-testing-agents/README.md
@@ -8,6 +8,10 @@ icon: "check-square"
 
 Learn how to test AI agents without making API calls. By mocking LLM responses and testing everything around the model — tool execution, decision routing, message construction, error handling — you can build fast, deterministic tests that catch real bugs.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/unit-testing-agents.gif" alt="A mocked LLM response flows through the agent harness so tool execution, routing, and behavioral contracts can be tested deterministically without live API calls." width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Mock LLM responses to create deterministic test scenarios

--- a/04-testing-evaluation/01-unit-testing-agents/README.md
+++ b/04-testing-evaluation/01-unit-testing-agents/README.md
@@ -9,7 +9,7 @@ icon: "check-square"
 Learn how to test AI agents without making API calls. By mocking LLM responses and testing everything around the model — tool execution, decision routing, message construction, error handling — you can build fast, deterministic tests that catch real bugs.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/unit-testing-agents.gif" alt="A mocked LLM response flows through the agent harness so tool execution, routing, and behavioral contracts can be tested deterministically without live API calls." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/testing-evaluation/unit-testing-agents.gif" alt="A mocked LLM response flows through the agent harness so tool execution, routing, and behavioral contracts can be tested deterministically without live API calls." width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/04-testing-evaluation/02-evals/README.md
+++ b/04-testing-evaluation/02-evals/README.md
@@ -8,6 +8,10 @@ icon: "bar-chart"
 
 Move beyond deterministic assertions to **statistical evaluation** of agent quality. Following Anthropic's eval-driven development methodology: define success criteria as eval tasks, score with multiple grader types, track quality over time, and catch regressions automatically.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/evals.gif" alt="A golden dataset feeds eval tasks through agent trials that are scored by code-based and LLM-as-judge graders to produce pass rates that surface regressions." width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Build code-based graders: keyword matching, regex, source citation, tool-call verification

--- a/04-testing-evaluation/02-evals/README.md
+++ b/04-testing-evaluation/02-evals/README.md
@@ -9,7 +9,7 @@ icon: "bar-chart"
 Move beyond deterministic assertions to **statistical evaluation** of agent quality. Following Anthropic's eval-driven development methodology: define success criteria as eval tasks, score with multiple grader types, track quality over time, and catch regressions automatically.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/evals.gif" alt="A golden dataset feeds eval tasks through agent trials that are scored by code-based and LLM-as-judge graders to produce pass rates that surface regressions." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/testing-evaluation/evals.gif" alt="A golden dataset feeds eval tasks through agent trials that are scored by code-based and LLM-as-judge graders to produce pass rates that surface regressions." width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/04-testing-evaluation/03-tracing-debugging/README.md
+++ b/04-testing-evaluation/03-tracing-debugging/README.md
@@ -10,6 +10,10 @@ When an agent does something unexpected, you need to know **exactly why**. Traci
 
 This tutorial teaches **observability as a first-class concern** using pure Python. No external dependencies — you learn the concepts, then apply them with production tools.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/tracing-debugging.gif" alt="Nested spans capture every LLM call, tool invocation, and decision point into a trace tree that exposes anti-patterns and pinpoints where an agent run failed." width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Build a span-based trace collector with context managers and decorators

--- a/04-testing-evaluation/03-tracing-debugging/README.md
+++ b/04-testing-evaluation/03-tracing-debugging/README.md
@@ -11,7 +11,7 @@ When an agent does something unexpected, you need to know **exactly why**. Traci
 This tutorial teaches **observability as a first-class concern** using pure Python. No external dependencies — you learn the concepts, then apply them with production tools.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/tracing-debugging.gif" alt="Nested spans capture every LLM call, tool invocation, and decision point into a trace tree that exposes anti-patterns and pinpoints where an agent run failed." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/testing-evaluation/tracing-debugging.gif" alt="Nested spans capture every LLM call, tool invocation, and decision point into a trace tree that exposes anti-patterns and pinpoints where an agent run failed." width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/04-testing-evaluation/04-red-teaming-safety/README.md
+++ b/04-testing-evaluation/04-red-teaming-safety/README.md
@@ -11,7 +11,7 @@ Agents have access to tools, execute code, and make autonomous decisions — a s
 All examples are educational and defensive. The purpose is to teach defense through understanding offense.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/red-teaming-safety.gif" alt="Adversarial prompts hit layered input, tool-call, and output guardrails while Attack Success Rate is measured across attack categories." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/testing-evaluation/red-teaming-safety.gif" alt="Adversarial prompts hit layered input, tool-call, and output guardrails while Attack Success Rate is measured across attack categories." width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/04-testing-evaluation/04-red-teaming-safety/README.md
+++ b/04-testing-evaluation/04-red-teaming-safety/README.md
@@ -10,6 +10,10 @@ Agents have access to tools, execute code, and make autonomous decisions — a s
 
 All examples are educational and defensive. The purpose is to teach defense through understanding offense.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/red-teaming-safety.gif" alt="Adversarial prompts hit layered input, tool-call, and output guardrails while Attack Success Rate is measured across attack categories." width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Test agents against **prompt injection** attacks (direct and indirect)

--- a/04-testing-evaluation/05-benchmarking/README.md
+++ b/04-testing-evaluation/05-benchmarking/README.md
@@ -9,7 +9,7 @@ icon: "bar-chart-2"
 When you need to decide between Claude Sonnet vs. GPT-4o-mini, or between two prompt strategies, benchmarking gives you **data instead of vibes**. Systematic head-to-head comparison across dimensions that matter: accuracy, latency, cost, and reliability.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/benchmarking.gif" alt="A model-by-prompt configuration matrix runs the same tasks to plot accuracy against cost and reveal the Pareto-optimal frontier." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/testing-evaluation/benchmarking.gif" alt="A model-by-prompt configuration matrix runs the same tasks to plot accuracy against cost and reveal the Pareto-optimal frontier." width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/04-testing-evaluation/05-benchmarking/README.md
+++ b/04-testing-evaluation/05-benchmarking/README.md
@@ -8,6 +8,10 @@ icon: "bar-chart-2"
 
 When you need to decide between Claude Sonnet vs. GPT-4o-mini, or between two prompt strategies, benchmarking gives you **data instead of vibes**. Systematic head-to-head comparison across dimensions that matter: accuracy, latency, cost, and reliability.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/benchmarking.gif" alt="A model-by-prompt configuration matrix runs the same tasks to plot accuracy against cost and reveal the Pareto-optimal frontier." width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Compare models on accuracy, latency, token usage, and cost

--- a/04-testing-evaluation/06-eval-frameworks/README.md
+++ b/04-testing-evaluation/06-eval-frameworks/README.md
@@ -9,7 +9,7 @@ icon: "puzzle-piece"
 Explore **production eval frameworks** recommended in Anthropic's [Demystifying Evals for AI Agents](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents). Each script demonstrates a different framework's approach to evaluating the same research assistant agent — from YAML-driven configs to pre-built scorers to tracing platforms.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/eval-frameworks.gif" alt="The same agent is evaluated through Promptfoo YAML configs, Braintrust AutoEvals scorers, and Langfuse tracing to compare framework tradeoffs." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/testing-evaluation/eval-frameworks.gif" alt="The same agent is evaluated through Promptfoo YAML configs, Braintrust AutoEvals scorers, and Langfuse tracing to compare framework tradeoffs." width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/04-testing-evaluation/06-eval-frameworks/README.md
+++ b/04-testing-evaluation/06-eval-frameworks/README.md
@@ -8,6 +8,10 @@ icon: "puzzle-piece"
 
 Explore **production eval frameworks** recommended in Anthropic's [Demystifying Evals for AI Agents](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents). Each script demonstrates a different framework's approach to evaluating the same research assistant agent — from YAML-driven configs to pre-built scorers to tracing platforms.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/eval-frameworks.gif" alt="The same agent is evaluated through Promptfoo YAML configs, Braintrust AutoEvals scorers, and Langfuse tracing to compare framework tradeoffs." width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Define eval suites declaratively using **Promptfoo's YAML configuration**

--- a/04-testing-evaluation/07-eval-harness/README.md
+++ b/04-testing-evaluation/07-eval-harness/README.md
@@ -8,6 +8,10 @@ icon: "award"
 
 The capstone project that **combines all five techniques** from this module into a single, reusable evaluation harness. Unit testing patterns, evals, tracing, red teaming, and benchmarking compose into a complete quality system for a real agent.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/eval-harness.gif" alt="Tasks flow through a unified pipeline that runs the traced agent, scores it with graders, runs safety and benchmark stages, and emits one combined quality report." width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Wire all 5 testing techniques into a unified evaluation pipeline

--- a/04-testing-evaluation/07-eval-harness/README.md
+++ b/04-testing-evaluation/07-eval-harness/README.md
@@ -9,7 +9,7 @@ icon: "award"
 The capstone project that **combines all five techniques** from this module into a single, reusable evaluation harness. Unit testing patterns, evals, tracing, red teaming, and benchmarking compose into a complete quality system for a real agent.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/eval-harness.gif" alt="Tasks flow through a unified pipeline that runs the traced agent, scores it with graders, runs safety and benchmark stages, and emits one combined quality report." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/testing-evaluation/eval-harness.gif" alt="Tasks flow through a unified pipeline that runs the traced agent, scores it with graders, runs safety and benchmark stages, and emits one combined quality report." width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/04-testing-evaluation/README.md
+++ b/04-testing-evaluation/README.md
@@ -8,7 +8,7 @@ description: "Measure quality, catch regressions, and build confidence in AI age
 Agents are non-deterministic — testing them requires different thinking. This module teaches the mental models, patterns, and techniques for building confidence in AI agents before shipping. Following Anthropic's principle of **eval-driven development**, you'll learn to define success criteria before building, measure quality continuously, and catch regressions automatically.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/testing-evaluation-overview.gif" alt="The module's progression builds from unit testing through evals, tracing, red teaming, benchmarking, and frameworks, culminating in a combined eval harness." width="820">
+  <img src="https://graphics.agenticloops.ai/animations/testing-evaluation/testing-evaluation-overview.gif" alt="The module's progression builds from unit testing through evals, tracing, red teaming, benchmarking, and frameworks, culminating in a combined eval harness." width="820">
 </p>
 
 ## 🗺️ Progression Path

--- a/04-testing-evaluation/README.md
+++ b/04-testing-evaluation/README.md
@@ -7,20 +7,9 @@ description: "Measure quality, catch regressions, and build confidence in AI age
 
 Agents are non-deterministic — testing them requires different thinking. This module teaches the mental models, patterns, and techniques for building confidence in AI agents before shipping. Following Anthropic's principle of **eval-driven development**, you'll learn to define success criteria before building, measure quality continuously, and catch regressions automatically.
 
-```mermaid
----
-config:
-  look: handDrawn
-  theme: neutral
----
-flowchart TD
-    A["1 · ✅ Unit Testing     "] -->|"+ scoring"| B["2 · 📊 Evals     "]
-    B -->|"+ observability"| C["3 · 🔍 Tracing     "]
-    C -->|"+ adversarial"| D["4 · 🔒 Red Teaming     "]
-    D -->|"+ comparison"| E["5 · ⚖️ Benchmarking     "]
-    E -->|"+ frameworks"| F["6 · 🧩 Eval Frameworks     "]
-    F -->|"combine all"| G["🏆 Eval Harness     "]
-```
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/testing-evaluation-overview.gif" alt="The module's progression builds from unit testing through evals, tracing, red teaming, benchmarking, and frameworks, culminating in a combined eval harness." width="820">
+</p>
 
 ## 🗺️ Progression Path
 

--- a/05-frameworks/01-no-framework/README.md
+++ b/05-frameworks/01-no-framework/README.md
@@ -10,7 +10,7 @@ status: "coming-soon"
 The raw SDK baseline. Pure Anthropic/OpenAI client code with no abstractions. This is your reference implementation — everything else is measured against it.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/no-framework.gif" alt="A bare agent loop wired directly to a provider SDK client, with no framework layer between the prompt, the model call, and tool execution." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/frameworks/no-framework.gif" alt="A bare agent loop wired directly to a provider SDK client, with no framework layer between the prompt, the model call, and tool execution." width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/05-frameworks/01-no-framework/README.md
+++ b/05-frameworks/01-no-framework/README.md
@@ -9,6 +9,10 @@ status: "coming-soon"
 
 The raw SDK baseline. Pure Anthropic/OpenAI client code with no abstractions. This is your reference implementation — everything else is measured against it.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/no-framework.gif" alt="A bare agent loop wired directly to a provider SDK client, with no framework layer between the prompt, the model call, and tool execution." width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Build a complete agent using only provider SDKs

--- a/05-frameworks/02-langgraph/README.md
+++ b/05-frameworks/02-langgraph/README.md
@@ -10,7 +10,7 @@ status: "coming-soon"
 Graph-based agent orchestration from LangChain. Define agents as nodes and edges with built-in state management and persistence.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/langgraph.gif" alt="A LangGraph agent modeled as a directed graph of nodes connected by conditional edges, routing shared state through checkpointed steps." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/frameworks/langgraph.gif" alt="A LangGraph agent modeled as a directed graph of nodes connected by conditional edges, routing shared state through checkpointed steps." width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/05-frameworks/02-langgraph/README.md
+++ b/05-frameworks/02-langgraph/README.md
@@ -9,6 +9,10 @@ status: "coming-soon"
 
 Graph-based agent orchestration from LangChain. Define agents as nodes and edges with built-in state management and persistence.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/langgraph.gif" alt="A LangGraph agent modeled as a directed graph of nodes connected by conditional edges, routing shared state through checkpointed steps." width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Model agent workflows as directed graphs

--- a/05-frameworks/03-pydantic-ai/README.md
+++ b/05-frameworks/03-pydantic-ai/README.md
@@ -9,6 +9,10 @@ status: "coming-soon"
 
 Type-safe agent framework built on Pydantic. Strong typing, dependency injection, and structured outputs as first-class citizens.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/pydantic-ai.gif" alt="A Pydantic AI agent passing typed inputs through dependency injection into a model call that returns runtime-validated structured outputs." width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Define agents with Pydantic models for type safety

--- a/05-frameworks/03-pydantic-ai/README.md
+++ b/05-frameworks/03-pydantic-ai/README.md
@@ -10,7 +10,7 @@ status: "coming-soon"
 Type-safe agent framework built on Pydantic. Strong typing, dependency injection, and structured outputs as first-class citizens.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/pydantic-ai.gif" alt="A Pydantic AI agent passing typed inputs through dependency injection into a model call that returns runtime-validated structured outputs." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/frameworks/pydantic-ai.gif" alt="A Pydantic AI agent passing typed inputs through dependency injection into a model call that returns runtime-validated structured outputs." width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/05-frameworks/04-google-adk/README.md
+++ b/05-frameworks/04-google-adk/README.md
@@ -9,6 +9,10 @@ status: "coming-soon"
 
 Google's Agent Development Kit. Multi-agent orchestration with built-in tool support and Gemini integration.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/google-adk.gif" alt="A Google ADK setup orchestrating multiple agents around native Gemini models with built-in tool definitions and execution primitives." width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Build agents using Google's ADK architecture

--- a/05-frameworks/04-google-adk/README.md
+++ b/05-frameworks/04-google-adk/README.md
@@ -10,7 +10,7 @@ status: "coming-soon"
 Google's Agent Development Kit. Multi-agent orchestration with built-in tool support and Gemini integration.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/google-adk.gif" alt="A Google ADK setup orchestrating multiple agents around native Gemini models with built-in tool definitions and execution primitives." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/frameworks/google-adk.gif" alt="A Google ADK setup orchestrating multiple agents around native Gemini models with built-in tool definitions and execution primitives." width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/05-frameworks/05-aws-strands/README.md
+++ b/05-frameworks/05-aws-strands/README.md
@@ -10,7 +10,7 @@ status: "coming-soon"
 AWS's agent SDK. Model-driven development with native AWS service integration and deployment tooling.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/aws-strands.gif" alt="An AWS Strands model-driven agent connected to native AWS services and deployment infrastructure tooling." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/frameworks/aws-strands.gif" alt="An AWS Strands model-driven agent connected to native AWS services and deployment infrastructure tooling." width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/05-frameworks/05-aws-strands/README.md
+++ b/05-frameworks/05-aws-strands/README.md
@@ -9,6 +9,10 @@ status: "coming-soon"
 
 AWS's agent SDK. Model-driven development with native AWS service integration and deployment tooling.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/aws-strands.gif" alt="An AWS Strands model-driven agent connected to native AWS services and deployment infrastructure tooling." width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Build agents using AWS Strands architecture

--- a/05-frameworks/06-crewai/README.md
+++ b/05-frameworks/06-crewai/README.md
@@ -9,6 +9,10 @@ status: "coming-soon"
 
 Role-based multi-agent collaboration. Define agents with roles, goals, and backstories that work together on complex tasks.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/crewai.gif" alt="A CrewAI crew of role-based agents with distinct goals and backstories delegating and collaborating to complete a shared task." width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Define agents with distinct roles, goals, and backstories

--- a/05-frameworks/06-crewai/README.md
+++ b/05-frameworks/06-crewai/README.md
@@ -10,7 +10,7 @@ status: "coming-soon"
 Role-based multi-agent collaboration. Define agents with roles, goals, and backstories that work together on complex tasks.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/crewai.gif" alt="A CrewAI crew of role-based agents with distinct goals and backstories delegating and collaborating to complete a shared task." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/frameworks/crewai.gif" alt="A CrewAI crew of role-based agents with distinct goals and backstories delegating and collaborating to complete a shared task." width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/05-frameworks/07-autogen/README.md
+++ b/05-frameworks/07-autogen/README.md
@@ -9,6 +9,10 @@ status: "coming-soon"
 
 Microsoft's multi-agent conversation framework. Agents communicate through structured conversations with configurable interaction patterns.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/autogen.gif" alt="An AutoGen multi-agent setup where agents exchange messages in a structured conversation with configurable interaction and termination patterns." width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Set up multi-agent conversations with AutoGen

--- a/05-frameworks/07-autogen/README.md
+++ b/05-frameworks/07-autogen/README.md
@@ -10,7 +10,7 @@ status: "coming-soon"
 Microsoft's multi-agent conversation framework. Agents communicate through structured conversations with configurable interaction patterns.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/autogen.gif" alt="An AutoGen multi-agent setup where agents exchange messages in a structured conversation with configurable interaction and termination patterns." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/frameworks/autogen.gif" alt="An AutoGen multi-agent setup where agents exchange messages in a structured conversation with configurable interaction and termination patterns." width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/05-frameworks/08-llamaindex/README.md
+++ b/05-frameworks/08-llamaindex/README.md
@@ -10,7 +10,7 @@ status: "coming-soon"
 Data-centric agent framework. Strong RAG primitives, knowledge graph integration, and document-aware agents.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/llamaindex.gif" alt="A LlamaIndex data-centric agent retrieving from documents and knowledge graphs through a RAG pipeline before reasoning over the results." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/frameworks/llamaindex.gif" alt="A LlamaIndex data-centric agent retrieving from documents and knowledge graphs through a RAG pipeline before reasoning over the results." width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/05-frameworks/08-llamaindex/README.md
+++ b/05-frameworks/08-llamaindex/README.md
@@ -9,6 +9,10 @@ status: "coming-soon"
 
 Data-centric agent framework. Strong RAG primitives, knowledge graph integration, and document-aware agents.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/llamaindex.gif" alt="A LlamaIndex data-centric agent retrieving from documents and knowledge graphs through a RAG pipeline before reasoning over the results." width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Build data-aware agents with LlamaIndex

--- a/05-frameworks/09-semantic-kernel/README.md
+++ b/05-frameworks/09-semantic-kernel/README.md
@@ -9,6 +9,10 @@ status: "coming-soon"
 
 Microsoft's AI orchestration SDK. Plugin architecture, planner system, and deep integration with Azure services.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/semantic-kernel.gif" alt="A Semantic Kernel setup where a planner decomposes a task and invokes plugin skills and functions integrated with Azure AI services." width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Build agents using Semantic Kernel's plugin system

--- a/05-frameworks/09-semantic-kernel/README.md
+++ b/05-frameworks/09-semantic-kernel/README.md
@@ -10,7 +10,7 @@ status: "coming-soon"
 Microsoft's AI orchestration SDK. Plugin architecture, planner system, and deep integration with Azure services.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/semantic-kernel.gif" alt="A Semantic Kernel setup where a planner decomposes a task and invokes plugin skills and functions integrated with Azure AI services." width="720">
+  <img src="https://graphics.agenticloops.ai/animations/frameworks/semantic-kernel.gif" alt="A Semantic Kernel setup where a planner decomposes a task and invokes plugin skills and functions integrated with Azure AI services." width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/05-frameworks/README.md
+++ b/05-frameworks/README.md
@@ -9,6 +9,10 @@ One agent, nine implementations. Build the same system with each framework so yo
 
 > 🚧 **Coming soon** — this module is under active development. [Subscribe to our Substack](https://agenticloopsai.substack.com) or ⭐️ star the repo to get notified when tutorials drop.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/frameworks-overview.gif" alt="The same reference agent built nine times across different frameworks, fanning out to highlight the structural trade-offs between each implementation." width="820">
+</p>
+
 ## 💡 Why This Module Exists
 
 After building agents from scratch in modules 01-03, you understand exactly what frameworks abstract away. Now you can make informed decisions about when a framework helps — and when it just adds complexity.

--- a/05-frameworks/README.md
+++ b/05-frameworks/README.md
@@ -10,7 +10,7 @@ One agent, nine implementations. Build the same system with each framework so yo
 > 🚧 **Coming soon** — this module is under active development. [Subscribe to our Substack](https://agenticloopsai.substack.com) or ⭐️ star the repo to get notified when tutorials drop.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/frameworks-overview.gif" alt="The same reference agent built nine times across different frameworks, fanning out to highlight the structural trade-offs between each implementation." width="820">
+  <img src="https://graphics.agenticloops.ai/animations/frameworks/frameworks-overview.gif" alt="The same reference agent built nine times across different frameworks, fanning out to highlight the structural trade-offs between each implementation." width="820">
 </p>
 
 ## 💡 Why This Module Exists

--- a/06-production/01-twelve-factor-agents/README.md
+++ b/06-production/01-twelve-factor-agents/README.md
@@ -10,7 +10,7 @@ status: "coming-soon"
 Principles for building production-grade agents. Inspired by the 12-factor app methodology, adapted for the unique challenges of LLM-powered systems.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/twelve-factor-agents.gif" alt="The twelve factors of production-grade agent design assembling into a coherent architecture" width="720">
+  <img src="https://graphics.agenticloops.ai/animations/production/twelve-factor-agents.gif" alt="The twelve factors of production-grade agent design assembling into a coherent architecture" width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/06-production/01-twelve-factor-agents/README.md
+++ b/06-production/01-twelve-factor-agents/README.md
@@ -9,6 +9,10 @@ status: "coming-soon"
 
 Principles for building production-grade agents. Inspired by the 12-factor app methodology, adapted for the unique challenges of LLM-powered systems.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/twelve-factor-agents.gif" alt="The twelve factors of production-grade agent design assembling into a coherent architecture" width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Apply 12-factor principles to agent architecture

--- a/06-production/02-deployment-strategies/README.md
+++ b/06-production/02-deployment-strategies/README.md
@@ -10,7 +10,7 @@ status: "coming-soon"
 Containers, serverless, and scaling patterns. How to package and ship agents that handle variable load and long-running tasks.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/deployment-strategies.gif" alt="Packaging an agent into containers and serverless deployments that scale with traffic" width="720">
+  <img src="https://graphics.agenticloops.ai/animations/production/deployment-strategies.gif" alt="Packaging an agent into containers and serverless deployments that scale with traffic" width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/06-production/02-deployment-strategies/README.md
+++ b/06-production/02-deployment-strategies/README.md
@@ -9,6 +9,10 @@ status: "coming-soon"
 
 Containers, serverless, and scaling patterns. How to package and ship agents that handle variable load and long-running tasks.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/deployment-strategies.gif" alt="Packaging an agent into containers and serverless deployments that scale with traffic" width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Package agents in containers for consistent deployment

--- a/06-production/03-monitoring-observability/README.md
+++ b/06-production/03-monitoring-observability/README.md
@@ -10,7 +10,7 @@ status: "coming-soon"
 Metrics, structured logging, and distributed tracing for production agents. Know when things break before your users tell you.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/monitoring-observability.gif" alt="Metrics, structured logs, and distributed traces flowing into dashboards and alerts for a running agent" width="720">
+  <img src="https://graphics.agenticloops.ai/animations/production/monitoring-observability.gif" alt="Metrics, structured logs, and distributed traces flowing into dashboards and alerts for a running agent" width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/06-production/03-monitoring-observability/README.md
+++ b/06-production/03-monitoring-observability/README.md
@@ -9,6 +9,10 @@ status: "coming-soon"
 
 Metrics, structured logging, and distributed tracing for production agents. Know when things break before your users tell you.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/monitoring-observability.gif" alt="Metrics, structured logs, and distributed traces flowing into dashboards and alerts for a running agent" width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Instrument agents with meaningful metrics

--- a/06-production/04-cost-optimization/README.md
+++ b/06-production/04-cost-optimization/README.md
@@ -10,7 +10,7 @@ status: "coming-soon"
 Token budgets, caching strategies, model routing, and knowing when a smaller model is the right call. Keep costs predictable as usage grows.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/cost-controls.gif" alt="Token budgets, caching, and model routing controlling agent spend as usage scales" width="720">
+  <img src="https://graphics.agenticloops.ai/animations/production/cost-controls.gif" alt="Token budgets, caching, and model routing controlling agent spend as usage scales" width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/06-production/04-cost-optimization/README.md
+++ b/06-production/04-cost-optimization/README.md
@@ -9,6 +9,10 @@ status: "coming-soon"
 
 Token budgets, caching strategies, model routing, and knowing when a smaller model is the right call. Keep costs predictable as usage grows.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/cost-controls.gif" alt="Token budgets, caching, and model routing controlling agent spend as usage scales" width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Set and enforce token budgets per request

--- a/06-production/05-security-guardrails/README.md
+++ b/06-production/05-security-guardrails/README.md
@@ -9,6 +9,10 @@ status: "coming-soon"
 
 Authentication, sandboxing, prompt injection defense, and tool-use permissions. Build agents that are safe to expose to untrusted input.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/security-guardrails.gif" alt="Authentication, sandboxing, and prompt-injection defenses shielding an agent from untrusted input" width="720">
+</p>
+
 ## 🎯 What You'll Learn
 
 - Implement authentication and authorization for agent access

--- a/06-production/05-security-guardrails/README.md
+++ b/06-production/05-security-guardrails/README.md
@@ -10,7 +10,7 @@ status: "coming-soon"
 Authentication, sandboxing, prompt injection defense, and tool-use permissions. Build agents that are safe to expose to untrusted input.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/security-guardrails.gif" alt="Authentication, sandboxing, and prompt-injection defenses shielding an agent from untrusted input" width="720">
+  <img src="https://graphics.agenticloops.ai/animations/production/security-guardrails.gif" alt="Authentication, sandboxing, and prompt-injection defenses shielding an agent from untrusted input" width="720">
 </p>
 
 ## 🎯 What You'll Learn

--- a/06-production/README.md
+++ b/06-production/README.md
@@ -8,7 +8,7 @@ description: "The gap between 'works on my laptop' and 'runs reliably at scale' 
 The gap between "works on my laptop" and "runs reliably at scale." Principles, deployment, monitoring, cost control, and security for agents serving real users.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/production-overview.gif" alt="An agent moving from a laptop demo to reliable production with deployment, monitoring, cost control, and security" width="820">
+  <img src="https://graphics.agenticloops.ai/animations/production/production-overview.gif" alt="An agent moving from a laptop demo to reliable production with deployment, monitoring, cost control, and security" width="820">
 </p>
 
 > 🚧 **Coming soon** — this module is under active development. [Subscribe to our Substack](https://agenticloopsai.substack.com) or ⭐️ star the repo to get notified when tutorials drop.

--- a/06-production/README.md
+++ b/06-production/README.md
@@ -7,6 +7,10 @@ description: "The gap between 'works on my laptop' and 'runs reliably at scale' 
 
 The gap between "works on my laptop" and "runs reliably at scale." Principles, deployment, monitoring, cost control, and security for agents serving real users.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/production-overview.gif" alt="An agent moving from a laptop demo to reliable production with deployment, monitoring, cost control, and security" width="820">
+</p>
+
 > 🚧 **Coming soon** — this module is under active development. [Subscribe to our Substack](https://agenticloopsai.substack.com) or ⭐️ star the repo to get notified when tutorials drop.
 
 ## 💡 Why This Module Matters

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 This is the repo for engineers who want to understand what's behind popular agents like **Claude Code**, **Codex**, and **GitHub Copilot** and how to build one by yourself. From your first LLM call to a production eval harness.
 
 <p align="center">
-  <img src="https://graphics.agenticloops.ai/animations/hero.gif" alt="The agent loop: an agent reasons, acts with tools, observes the result, and repeats until the task is done." width="860">
+  <img src="https://graphics.agenticloops.ai/animations/brand/hero.gif" alt="The agent loop: an agent reasons, acts with tools, observes the result, and repeats until the task is done." width="860">
 </p>
 
 > Building AI agents is engineering, not magic. Master the constraints, not the hype.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@
 
 This is the repo for engineers who want to understand what's behind popular agents like **Claude Code**, **Codex**, and **GitHub Copilot** and how to build one by yourself. From your first LLM call to a production eval harness.
 
+<p align="center">
+  <img src="https://graphics.agenticloops.ai/animations/hero.gif" alt="The agent loop: an agent reasons, acts with tools, observes the result, and repeats until the task is done." width="860">
+</p>
+
 > Building AI agents is engineering, not magic. Master the constraints, not the hype.
 
 ## ❓ Why you need to learn this?


### PR DESCRIPTION
## What

Replaces Mermaid diagrams (and adds diagrams where missing) with hosted **animated GIFs** across the whole tutorial set — one per tutorial, one per module overview, and a hero on the root README. **49 embeds** total, all served from [graphics.agenticloops.ai](https://graphics.agenticloops.ai).

| Surface | Count |
|---|---|
| Root README hero | 1 |
| Module overviews (01–06) | 6 |
| 01-foundations tutorials | 6 |
| 02-effective-agents tutorials | 7 |
| 03-advanced-techniques tutorials | 8 |
| 04-testing-evaluation tutorials | 7 |
| 05-frameworks tutorials | 9 |
| 06-production tutorials | 5 |

## Why

The animation source lives in the separate `agenticloops-ai-graphics` repo (schema-driven `diagram_spec` → captured GIFs), deployed to `graphics.agenticloops.ai` with edge caching + analytics. Embedding by **absolute URL** keeps this repo free of binary assets while every tutorial renders a rich animated diagram on GitHub.

## Verification

- All 49 embedded GIF URLs are live (`200 image/gif`) and deployed.
- 1:1 mapping verified — every scene GIF is embedded; no broken references.
- Mermaid replacements preserve surrounding content (e.g. progression tables); fresh inserts sit after each tutorial's intro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)