### PR TITLE
docs: make Geoffrey Huntley quote responsive on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,28 +46,22 @@ If you find this useful, a ⭐️ star helps us know we're on the right track. J
 ## ❓ Why you need to learn this?
 Agent fluency is the new data-structures interview. We teach it **from first principles** - you build the loop, the tool calls, the memory, and the evals yourself before we ever introduce a framework. No magic. No black boxes. Just the primitives, in the order they were invented.
 
-<table>
-<tr>
-<td width="170" align="center" valign="middle">
-<a href="https://ghuntley.com"><img src="https://avatars.githubusercontent.com/u/127353?v=4" width="140" alt="Geoffrey Huntley" /></a>
-<br/>
-<b>Geoffrey Huntley</b>
-<br/>
+<a href="https://ghuntley.com"><img src="https://avatars.githubusercontent.com/u/127353?v=4" width="72" align="left" alt="Geoffrey Huntley" /></a>
+
+**[Geoffrey Huntley](https://ghuntley.com)**<br/>
 <sub>creator of <a href="https://ghuntley.com/ralph/">Ralph&nbsp;Wiggum</a></sub>
-</td>
-<td valign="middle">
-<em>How many of you actually can pull out a whiteboard and build me an agent? Can you show me the inferencing loop?</em>
-<br/>
-<b><em>If you don't know this, your career is in jeopardy.</em></b>
-<br/>
-<em>What is a tool call? If you don't know what that is, you need to learn what it is and all these basic fundamentals. I preference candidates if they know what a tool call is, how the inferencing loop works, pull out a whiteboard — the same way we used to say, show me a linked list, reverse me this data structure.</em>
-<br/>
-<em><b>This is now baseline knowledge</b> because we're getting candidates in that can answer this stuff.</em>
-<br/>
-<a href="https://www.youtube.com/clip/UgkxNl2grro6BiM_x9bGSH_xMOSl32fxvthr">▶️ Fundamental skills and knowledge you must have in 2026 for SWE</a>
-</td>
-</tr>
-</table>
+
+<br clear="left" />
+
+> _How many of you actually can pull out a whiteboard and build me an agent? Can you show me the inferencing loop?_
+>
+> **_If you don't know this, your career is in jeopardy._**
+>
+> _What is a tool call? If you don't know what that is, you need to learn what it is and all these basic fundamentals. I preference candidates if they know what a tool call is, how the inferencing loop works, pull out a whiteboard — the same way we used to say, show me a linked list, reverse me this data structure._
+>
+> _**This is now baseline knowledge** because we're getting candidates in that can answer this stuff._
+>
+> [▶️ Fundamental skills and knowledge you must have in 2026 for SWE](https://www.youtube.com/clip/UgkxNl2grro6BiM_x9bGSH_xMOSl32fxvthr)
 
 **All the answers are in this repo.** What a tool call is, how the inferencing loop works, what lives in the context — you won't just read the answers, you'll build them with your own hands, starting in [01 - Foundations](01-foundations/README.md). Next interview, you're the one at the whiteboard drawing the loop.
 

--- a/README.md
+++ b/README.md
@@ -46,22 +46,28 @@ If you find this useful, a ⭐️ star helps us know we're on the right track. J
 ## ❓ Why you need to learn this?
 Agent fluency is the new data-structures interview. We teach it **from first principles** - you build the loop, the tool calls, the memory, and the evals yourself before we ever introduce a framework. No magic. No black boxes. Just the primitives, in the order they were invented.
 
-<a href="https://ghuntley.com"><img src="https://avatars.githubusercontent.com/u/127353?v=4" width="72" align="left" alt="Geoffrey Huntley" /></a>
-
-**[Geoffrey Huntley](https://ghuntley.com)**<br/>
-<sub>creator of <a href="https://ghuntley.com/ralph/">Ralph&nbsp;Wiggum</a></sub>
-
-<br clear="left" />
-
-> _How many of you actually can pull out a whiteboard and build me an agent? Can you show me the inferencing loop?_
->
-> **_If you don't know this, your career is in jeopardy._**
->
-> _What is a tool call? If you don't know what that is, you need to learn what it is and all these basic fundamentals. I preference candidates if they know what a tool call is, how the inferencing loop works, pull out a whiteboard — the same way we used to say, show me a linked list, reverse me this data structure._
->
-> _**This is now baseline knowledge** because we're getting candidates in that can answer this stuff._
->
-> [▶️ Fundamental skills and knowledge you must have in 2026 for SWE](https://www.youtube.com/clip/UgkxNl2grro6BiM_x9bGSH_xMOSl32fxvthr)
+<table>
+<tr>
+<td width="22%" align="center" valign="middle">
+<a href="https://ghuntley.com"><img src="https://avatars.githubusercontent.com/u/127353?v=4" width="72" alt="Geoffrey Huntley" /></a>
+<br/>
+<b>Geoffrey Huntley</b>
+<br/>
+<sub>creator of <a href="https://ghuntley.com/ralph/">Ralph Wiggum</a></sub>
+</td>
+<td width="78%" valign="middle">
+<em>How many of you actually can pull out a whiteboard and build me an agent? Can you show me the inferencing loop?</em>
+<br/>
+<b><em>If you don't know this, your career is in jeopardy.</em></b>
+<br/>
+<em>What is a tool call? If you don't know what that is, you need to learn what it is and all these basic fundamentals. I preference candidates if they know what a tool call is, how the inferencing loop works, pull out a whiteboard — the same way we used to say, show me a linked list, reverse me this data structure.</em>
+<br/>
+<em><b>This is now baseline knowledge</b> because we're getting candidates in that can answer this stuff.</em>
+<br/>
+<a href="https://www.youtube.com/clip/UgkxNl2grro6BiM_x9bGSH_xMOSl32fxvthr">▶️ Fundamental skills and knowledge you must have in 2026 for SWE</a>
+</td>
+</tr>
+</table>
 
 **All the answers are in this repo.** What a tool call is, how the inferencing loop works, what lives in the context — you won't just read the answers, you'll build them with your own hands, starting in [01 - Foundations](01-foundations/README.md). Next interview, you're the one at the whiteboard drawing the loop.
 


### PR DESCRIPTION
The quote used a two-column HTML table with a fixed 170px avatar cell.
GitHub does not stack table cells on narrow viewports, so on mobile the
quote text was squeezed into a narrow column beside the avatar.

Replace the table with a single-column layout: avatar and attribution
float above, quote as a native blockquote that reflows at any width.