### PR TITLE
Fix duplicate chunks in recursive text splitting

### DIFF
--- a/03-advanced-techniques/06-rag-techniques/rag/chunker.py
+++ b/03-advanced-techniques/06-rag-techniques/rag/chunker.py
@@ -86,6 +86,7 @@ def _split_recursive(text: str, chunk_size: int, separators: list[str]) -> list[
                 else:
                     if current:
                         result.append(current)
+                        current = ""
                     # If a single part exceeds chunk_size, split it with finer separators
                     if len(part) > chunk_size:
                         remaining_seps = separators[separators.index(sep) + 1 :]


### PR DESCRIPTION
## Summary

Reset the current buffer after appending it to the result when an oversized part is recursively split.

## Problem

Previously, current remained populated after being added to result. In subsequent loop iterations, the stale content could be reused and
included in multiple chunks, causing unintended duplication.

## Changes

- Clear current immediately after appending it to result.
- Preserve the existing recursive splitting and chunk overlap behavior.

## Verification

Tested recursive splitting with oversized parts and confirmed that previously emitted content is not duplicated in subsequent chunks.